### PR TITLE
Add subfolder for each image lists, Add failure link storage & Code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@
 - The default file name is, 'Album ID' + '_b' + 'index'.'Image format'
 - Currently, the script is a single-threaded download method; if the number of images for a single user is large, it may take quite a long time.
 - This script will probably not be modified again; if there are running errors, you can raise issues, but there is no guarantee to change.
+
+## TODO
+
+- Add config files to record downloaded post!
+- use wget method to download failed images

--- a/README.md
+++ b/README.md
@@ -1,19 +1,29 @@
 # Bilibili相簿下载(Bilibili Album Download)
+
 ## 中文介绍
+
 ### 快速食用
-- 下载bilibili_album.py到任意一个文件夹
-- python bilibili_album.py <bilibili用户id>
+
+- 下载 `bilibili_album.py` 到任意一个文件夹
+    `python bilibili_album.py <bilibili user id>`
 
 ### 注意事项
-* 默认下载文件夹为，与脚本同级目录下，以Bilibili用户ID命名的文件夹
-* 默认文件命名为，绘画作品ID + 下划线 + b + 序号.图片格式
-* 目前脚本为单线程下载方式，单个用户图片数量多的话，需要时间可能有点长
-* 本脚本大概率不会再修改，如果有运行问题，可以提issues。但不保证会改（
+
+- 默认下载文件夹为，与脚本同级目录下，以Bilibili用户ID命名的文件夹
+- 默认文件命名为，'绘画作品ID' + '_b' + '序号'.'图片格式'
+- 目前脚本为单线程下载方式，单个用户图片数量多的话，需要时间可能有点长
+- 本脚本大概率不会再修改，如果有运行问题，可以提issues。但不保证会改
 
 ## English Version
+
 ### Quick Start
-- Download bilibili_album.py to any directory
-- python bilibili_album.py <bilibili user id>
-  
+
+- Download `bilibili_album.py` to any directory
+    `python bilibili_album.py <bilibili user id>`
+
 ### Attentions
-* Please read the Chinese ver.
+
+- The default download folder is a folder named after the Bilibili user ID at the same level as the script
+- The default file name is, 'Album ID' + '_b' + 'index'.'Image format'
+- Currently, the script is a single-threaded download method; if the number of images for a single user is large, it may take quite a long time.
+- This script will probably not be modified again; if there are running errors, you can raise issues, but there is no guarantee to change.

--- a/bilibili_album.py
+++ b/bilibili_album.py
@@ -1,102 +1,106 @@
-#coding=utf-8
-import requests,os,sys,math
+# coding=utf-8
+import requests, os, sys, math
 
-basicApiUrl='https://api.vc.bilibili.com/link_draw/v1/doc/upload_count?uid='
-apiUrl='https://api.vc.bilibili.com/link_draw/v1/doc/doc_list?page_size=30&biz=all&uid='
-headers={
-	'Referer':'https://space.bilibili.com/',
-	'User-Agent':'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 Safari/537.36'
+basicApiUrl = "https://api.vc.bilibili.com/link_draw/v1/doc/upload_count?uid="
+apiUrl = (
+    "https://api.vc.bilibili.com/link_draw/v1/doc/doc_list?page_size=30&biz=all&uid="
+)
+headers = {
+    "Referer": "https://space.bilibili.com/",
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 Safari/537.36",
 }
 
 # Get the amount of all draws
 # If error return 0
 def getTotalDraw(bid):
-	try:
-		req=requests.get(basicApiUrl+bid,headers=headers)
-		rspJson = req.json()
-	except:
-		return 0
-	
-	if('data' in rspJson and 'all_count' in rspJson['data']):
-		return int(rspJson['data']['all_count'])
-		
-	return 0
+    try:
+        req = requests.get(basicApiUrl + bid, headers=headers)
+        rspJson = req.json()
+    except:
+        return 0
+
+    if "data" in rspJson and "all_count" in rspJson["data"]:
+        return int(rspJson["data"]["all_count"])
+
+    return 0
+
 
 # Get the draw list, 30 draws in each page
-def downloadDrawList(bid,page):
-	url = apiUrl+bid
-	
-	# Add page num
-	url = url+'&page_num='+str(page)
-	
-	try:
-		req=requests.get(url,timeout=5,headers=headers)
-		rspJson = req.json()
-		
-		# Get all items in a range
-		items = rspJson['data']['items']
-		
-		for i in items:
-			urls = {}
-			did = str(i['doc_id'])
-			
-			# Single item traversal
-			count = 0
-			for j in i['pictures']:
-				urls[count]=j['img_src']
-				count+=1
-			
-			# Download
-			downloadDraw(bid,did,urls)
-	except Exception as e:
-		print(e)
-		pass
+def downloadDrawList(bid, page):
+    url = apiUrl + bid
+
+    # Add page num
+    url = url + "&page_num=" + str(page)
+
+    try:
+        req = requests.get(url, timeout=5, headers=headers)
+        rspJson = req.json()
+
+        # Get all items in a range
+        items = rspJson["data"]["items"]
+
+        for i in items:
+            urls = {}
+            did = str(i["doc_id"])
+
+            # Single item traversal
+            count = 0
+            for j in i["pictures"]:
+                urls[count] = j["img_src"]
+                count += 1
+
+            # Download
+            downloadDraw(bid, did, urls)
+    except Exception as e:
+        print(e)
+        pass
+
 
 # Download draws
-def downloadDraw(bid,did,urls):
-	count = 0
-	for i in range(len(urls)):
-		u = urls[i]
-		try:
-			# Get image format from url
-			suffix = u.split(".")[-1]
-			
-			# File naming
-			## bid: Bilibili user id
-			## did: Draw id
-			fileName = did+'_b'+str(count)+'.'+suffix
-			
-			if(os.path.exists('./'+bid+'/'+fileName)):
-				print('Skipped '+did+' '+u)
-				count+=1
-				continue
-			print('Downloading '+did+' '+u)
-			# Download single image
-			req = requests.get(u,timeout=20,headers=headers)			
-			# Create image file
-			with open('./'+bid+'/'+fileName,'wb') as f:
-				f.write(req.content)
-		except Exception as e:
-			print(e)
-			print('Fail to download: '+did+' '+u)
-			
-		count+=1
+def downloadDraw(bid, did, urls):
+    count = 0
+    for i in range(len(urls)):
+        u = urls[i]
+        try:
+            # Get image format from url
+            suffix = u.split(".")[-1]
 
-if __name__=='__main__':
-	if(len(sys.argv)<2):
-		print('Please enter the bilibili user id.')
-		sys.exit(0)
-	
-	bid = str(sys.argv[1])
-	
-	# Create drawer's directory
-	try:
-		os.makedirs('./'+bid)
-	except:
-		pass
+            # File naming
+            ## bid: Bilibili user id
+            ## did: Draw id
+            fileName = did + "_b" + str(count) + "." + suffix
 
-	totalDraw = getTotalDraw(bid)
-	totalPage = math.ceil(totalDraw/30)
-	for page in range(totalPage):
-		downloadDrawList(bid,page)
-	
+            if os.path.exists("./" + bid + "/" + fileName):
+                print("Skipped " + did + " " + u)
+                count += 1
+                continue
+            print("Downloading " + did + " " + u)
+            # Download single image
+            req = requests.get(u, timeout=20, headers=headers)
+            # Create image file
+            with open("./" + bid + "/" + fileName, "wb") as f:
+                f.write(req.content)
+        except Exception as e:
+            print(e)
+            print("Fail to download: " + did + " " + u)
+
+        count += 1
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Please enter the bilibili user id.")
+        sys.exit(0)
+
+    bid = str(sys.argv[1])
+
+    # Create drawer's directory
+    try:
+        os.makedirs("./" + bid)
+    except:
+        pass
+
+    totalDraw = getTotalDraw(bid)
+    totalPage = math.ceil(totalDraw / 30)
+    for page in range(totalPage):
+        downloadDrawList(bid, page)


### PR DESCRIPTION
- Add subfolder for each image lists
    - add new function `downloadAll()` function and create a failed.txt inside each `usrDir`
    - add `usrDir`, `date`, and `desc` arguments in `downloadDraw()` function to create subfolder for each image list
-  Add failure link storage
    - add `failed` in each `uid` folder to store the failed link for manual downloading or reruning the script later
- Code formatting
    - format the code using [black](https://github.com/psf/black) for better readability
- Update README
    - fix typos & update English translations